### PR TITLE
Support AWS Archiving

### DIFF
--- a/archive.py
+++ b/archive.py
@@ -24,8 +24,6 @@ class Archive(object):
     """Save content lzma compressed at default level to object store through boto."""
 
     def __init__(self, aws_id, aws_secret, server, bucket, object_prefix=""):
-        aws_id = base64.b64encode(aws_id)
-        aws_secret = hashlib.md5(aws_secret).hexdigest()
         hs3 = S3Connection(aws_access_key_id=aws_id,
                            aws_secret_access_key=aws_secret,
                            host=server)

--- a/archive.py
+++ b/archive.py
@@ -4,8 +4,6 @@ Archive messages compress with lzma to HCP using boto.
 
 # pylint: disable=too-few-public-methods,too-many-arguments
 
-import base64
-import hashlib
 import io
 import json
 


### PR DESCRIPTION
Use AWS instead of HCP for archiving usages, AWS is now being used in operation.